### PR TITLE
Add flashcard viewer with flipping animation

### DIFF
--- a/src/app/flashcards/[setId]/page.tsx
+++ b/src/app/flashcards/[setId]/page.tsx
@@ -1,27 +1,51 @@
 "use client";
+
+import { useEffect, useState } from "react";
+import { useParams, useRouter } from "next/navigation";
+import { FlashcardSet } from "@/lib/types";
 import Flashcard from "@/components/Flashcard/Flashcard";
 import FlashcardNavigation from "@/components/Flashcard/FlashcardNavigation";
 import ProgressBar from "@/components/Flashcard/ProgressBar";
 
 export default function FlashcardSetPage() {
+  const [setData, setSetData] = useState<FlashcardSet | null>(null);
+  const [current, setCurrent] = useState(0);
+
+   if (!setData) {
+    return (
+      <div className="p-6 text-center text-gray-600">
+        <p>Loading set...</p>
+        <div className="mt-4 animate-spin rounded-full h-8 w-8 border-t-2 border-b-2 border-blue-500 mx-auto"></div>
+      </div>
+    );
+  }
+
+  if (setData.cards.length === 0) {
+    return (
+      <div className="p-6 text-center text-gray-500">
+        <p>This set has no cards yet.</p>
+      </div>
+    );
+  }
+  const card = setData.cards[current];
   return (
     <div className="max-w-xl mx-auto p-6 text-center">
-      <h1 className="text-2xl font-bold mb-4">{}</h1>
-      <p className="text-gray-500 mb-6">{}</p>
+      <h1 className="text-2xl font-bold mb-4">{setData.name}</h1>
+      <p className="text-gray-500 mb-6">{setData.description}</p>
 
       <Flashcard
-        front={}
-        back={}
+        front={card.front}
+        back={card.back}
         showBack={}
         onFlip={}
       />
       <FlashcardNavigation
-        current={}
-        total={}
+        current={current}
+        total={setData.cards.length}
         onPrev={}
         onNext={}
       />
-      <ProgressBar current={} total={} />
+      <ProgressBar current={current} total={setData.cards.length} />
 
     </div>
   );

--- a/src/app/flashcards/[setId]/page.tsx
+++ b/src/app/flashcards/[setId]/page.tsx
@@ -8,10 +8,28 @@ import FlashcardNavigation from "@/components/Flashcard/FlashcardNavigation";
 import ProgressBar from "@/components/Flashcard/ProgressBar";
 
 export default function FlashcardSetPage() {
+  const params = useParams();
+  const setId = params.setId;
+  const router = useRouter();
   const [setData, setSetData] = useState<FlashcardSet | null>(null);
   const [current, setCurrent] = useState(0);
 
-   if (!setData) {
+
+  useEffect(() => {
+    if (typeof setId !== "string") {
+      router.push("/");
+      return;
+    }
+    const loadData = () => {
+      const sets = JSON.parse(localStorage.getItem("flashcardSets") || "[]");
+      const found = sets.find((s: FlashcardSet) => s.id === setId);
+      if (!found) return router.push("/");
+      setSetData(found);
+    };
+    loadData();
+  }, [setId, router]);
+
+  if (!setData) {
     return (
       <div className="p-6 text-center text-gray-600">
         <p>Loading set...</p>
@@ -36,14 +54,14 @@ export default function FlashcardSetPage() {
       <Flashcard
         front={card.front}
         back={card.back}
-        showBack={}
-        onFlip={}
+        showBack={ }
+        onFlip={ }
       />
       <FlashcardNavigation
         current={current}
         total={setData.cards.length}
-        onPrev={}
-        onNext={}
+        onPrev={ }
+        onNext={ }
       />
       <ProgressBar current={current} total={setData.cards.length} />
 

--- a/src/app/flashcards/[setId]/page.tsx
+++ b/src/app/flashcards/[setId]/page.tsx
@@ -1,0 +1,28 @@
+"use client";
+import Flashcard from "@/components/Flashcard/Flashcard";
+import FlashcardNavigation from "@/components/Flashcard/FlashcardNavigation";
+import ProgressBar from "@/components/Flashcard/ProgressBar";
+
+export default function FlashcardSetPage() {
+  return (
+    <div className="max-w-xl mx-auto p-6 text-center">
+      <h1 className="text-2xl font-bold mb-4">{}</h1>
+      <p className="text-gray-500 mb-6">{}</p>
+
+      <Flashcard
+        front={}
+        back={}
+        showBack={}
+        onFlip={}
+      />
+      <FlashcardNavigation
+        current={}
+        total={}
+        onPrev={}
+        onNext={}
+      />
+      <ProgressBar current={} total={} />
+
+    </div>
+  );
+}

--- a/src/app/flashcards/[setId]/page.tsx
+++ b/src/app/flashcards/[setId]/page.tsx
@@ -13,7 +13,7 @@ export default function FlashcardSetPage() {
   const router = useRouter();
   const [setData, setSetData] = useState<FlashcardSet | null>(null);
   const [current, setCurrent] = useState(0);
-
+  const [showBack, setShowBack] = useState(false);
 
   useEffect(() => {
     if (typeof setId !== "string") {
@@ -28,6 +28,18 @@ export default function FlashcardSetPage() {
     };
     loadData();
   }, [setId, router]);
+
+  const handleNext = () => {
+    setShowBack(false);
+    setCurrent((prev) =>
+      setData && prev < setData.cards.length - 1 ? prev + 1 : prev
+    );
+  };
+
+  const handlePrev = () => {
+    setShowBack(false);
+    setCurrent((prev) => (prev > 0 ? prev - 1 : prev));
+  };
 
   if (!setData) {
     return (
@@ -54,14 +66,14 @@ export default function FlashcardSetPage() {
       <Flashcard
         front={card.front}
         back={card.back}
-        showBack={ }
-        onFlip={ }
+        showBack={showBack}
+        onFlip={() => setShowBack(!showBack)}
       />
       <FlashcardNavigation
         current={current}
         total={setData.cards.length}
-        onPrev={ }
-        onNext={ }
+        onPrev={handlePrev}
+        onNext={handleNext}
       />
       <ProgressBar current={current} total={setData.cards.length} />
 


### PR DESCRIPTION
This pull request introduces a new client-side page for viewing and interacting with a specific flashcard set. The page loads flashcard data from local storage, displays the set's details, and provides navigation and progress tracking for studying flashcards.

Flashcard set viewing and navigation:

* Added a new page component `src/app/flashcards/[setId]/page.tsx` that loads a flashcard set by ID from local storage and displays its name, description, and cards. ([src/app/flashcards/[setId]/page.tsxR1-R82](diffhunk://#diff-a96b67dfd43b913d73f2a8c503d2b50ff7fe78af716497de085ba84b580a7202R1-R82))
* Implemented navigation controls (`handleNext`, `handlePrev`) and card flipping logic, allowing users to move between cards and view both sides. ([src/app/flashcards/[setId]/page.tsxR1-R82](diffhunk://#diff-a96b67dfd43b913d73f2a8c503d2b50ff7fe78af716497de085ba84b580a7202R1-R82))

User experience improvements:

* Included loading and empty state handling for cases where the set data is not yet available or contains no cards. ([src/app/flashcards/[setId]/page.tsxR1-R82](diffhunk://#diff-a96b67dfd43b913d73f2a8c503d2b50ff7fe78af716497de085ba84b580a7202R1-R82))
* Integrated `Flashcard`, `FlashcardNavigation`, and `ProgressBar` components for a complete study session experience. ([src/app/flashcards/[setId]/page.tsxR1-R82](diffhunk://#diff-a96b67dfd43b913d73f2a8c503d2b50ff7fe78af716497de085ba84b580a7202R1-R82))