### PR TITLE
Add flashcard edit 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,36 +1,105 @@
-This is a [Next.js](https://nextjs.org) project bootstrapped with [`create-next-app`](https://nextjs.org/docs/app/api-reference/cli/create-next-app).
 
-## Getting Started
+# 🧠 Flashcards App
 
-First, run the development server:
+A flashcard learning application built with **Next.js**, **TypeScript**, and **Tailwind CSS**. Users can create, edit, delete, and view custom flashcard sets. All data is stored locally using `localStorage`.
 
-```bash
-npm run dev
-# or
-yarn dev
-# or
-pnpm dev
-# or
-bun dev
+## ✨ Features
+
+- Create custom flashcard sets
+- Edit and delete existing sets
+- Add multiple flashcards with front/back content
+- Basic validation and notifications with `react-toastify`
+- Responsive and modern user interface
+- Fully local storage (no backend for now)
+
+## 🧱 Folder Structure
+
+```
+📁 app/
+├── create-set          → Page to create a new set
+├── edit/[setId]        → Page to edit an existing set
+├── view/[setId]        → Page to view a set
+├── page.tsx            → Home page with all sets listed
+
+📁 components/
+├── FlashcardPreview.tsx
+├── SetCard.tsx
+└── InputsFlashcard/
+    ├── SetNameInput.tsx
+    ├── SetDescriptionInput.tsx
+    ├── FlashcardInput.tsx
+    └── CardFormActions.tsx
+
+📁 lib/
+└── types.ts            → Type definitions
+
+📁 public/
+└── (static assets if any)
+
+📄 tailwind.config.ts
+📄 tsconfig.json
+📄 package.json
 ```
 
-Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
+## 🛠️ Tech Stack
 
-You can start editing the page by modifying `app/page.tsx`. The page auto-updates as you edit the file.
+- [Next.js 15](https://nextjs.org/)
+- [React 18](https://reactjs.org/)
+- [TypeScript](https://www.typescriptlang.org/)
+- [Tailwind CSS](https://tailwindcss.com/)
+- [React Toastify](https://fkhadra.github.io/react-toastify/)
+- [uuid](https://www.npmjs.com/package/uuid)
 
-This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.
+## 🚀 Getting Started
 
-## Learn More
+```bash
+# Clone the repo
+git clone https://github.com/your-username/flashcards-app.git
+cd flashcards-app
 
-To learn more about Next.js, take a look at the following resources:
+# Install dependencies
+npm install
 
-- [Next.js Documentation](https://nextjs.org/docs) - learn about Next.js features and API.
-- [Learn Next.js](https://nextjs.org/learn) - an interactive Next.js tutorial.
+# Run in development mode
+npm run dev
+```
 
-You can check out [the Next.js GitHub repository](https://github.com/vercel/next.js) - your feedback and contributions are welcome!
+The app will be available at `http://localhost:3000`.
 
-## Deploy on Vercel
+## 🧪 Testing
 
-The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
+This project is set up to use **Jest** for testing:
 
-Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.
+```bash
+npm run test        # Run tests
+npm run test:watch  # Run tests in watch mode
+```
+
+> Make sure Jest is correctly configured in your environment.
+
+## 📦 Build for Production
+
+```bash
+npm run build
+npm start
+```
+
+## 📌 Notes
+
+- Currently uses `localStorage`, so data is only saved locally per browser.
+- Easily extendable to support a backend in the future (e.g., Supabase, Firebase).
+
+## 💡 Future Improvements
+
+- Search functionality for sets
+- Study / Review mode for flashcards
+- Export and import sets
+- Cloud storage integration
+
+## 🧑‍💻 Author
+
+Built by [Brunonxale].
+
+---
+
+Feel free to contribute or suggest new features!

--- a/src/app/flashcards/edit/[setId]/page.tsx
+++ b/src/app/flashcards/edit/[setId]/page.tsx
@@ -26,19 +26,28 @@ export default function EditFlashcardSetPage() {
     }
   }, [setId, notFound]);
 
+  if (notFound) return <p className="p-6">Set not found</p>;
+
+  if (!setData) return <p className="p-6">Loading set for editing...</p>;
+
+  const handleChange = (field: string, value: string) => {
+    if (!setData) return;
+    setSetData({ ...setData, [field]: value });
+  };
+
   return (
     <div className="max-w-2xl mx-auto p-6 text-gray-800">
       <h1 className="text-3xl font-bold mb-6 text-blue-700">✏️ Edit Flashcard Set</h1>
 
       <SetNameInput
-        value={ }
-        onChange={() => ()}
-        error={ }
+        value={setData.name}
+        onChange={(value: string) => handleChange("name", value)}
+        error={}
       />
 
       <SetDescriptionInput
-        value={ }
-        onChange={() => ()}
+        value={setData.description ?? ""}
+        onChange={(value: string) => handleChange("description", value)}
       />
 
       <h2 className="text-xl font-semibold mb-4 text-blue-600">🧠 Cards</h2>

--- a/src/app/flashcards/edit/[setId]/page.tsx
+++ b/src/app/flashcards/edit/[setId]/page.tsx
@@ -1,7 +1,9 @@
 "use client";
+
 import { useParams, useRouter } from "next/navigation";
 import { useEffect, useState } from "react";
 import { FlashcardSet } from "@/lib/types";
+import { v4 as uuidv4 } from "uuid";
 
 import FlashcardInput from "@/components/InputsFlashcard/FlashcardInput";
 import CardFormActions from "@/components/InputsFlashcard/CardFormActions";
@@ -29,6 +31,7 @@ export default function EditFlashcardSetPage() {
     }
   }, [setId, notFound]);
 
+
   if (notFound) return <p className="p-6">Set not found</p>;
 
   if (!setData) return <p className="p-6">Loading set for editing...</p>;
@@ -43,6 +46,14 @@ export default function EditFlashcardSetPage() {
     const newCards = [...setData.cards];
     newCards[index][field] = value;
     setSetData({ ...setData, cards: newCards });
+  };
+
+  const handleAddCard = () => {
+    if (!setData) return;
+    setSetData({
+      ...setData,
+      cards: [...setData.cards, { id: uuidv4(), front: "", back: "" }],
+    });
   };
 
   const handleDeleteCard = (index: number) => {
@@ -78,6 +89,23 @@ export default function EditFlashcardSetPage() {
     return !hasErrors;
   };
 
+  const handleSubmit = () => {
+    if (!validate()) return;
+
+    const sets = JSON.parse(localStorage.getItem("flashcardSets") || "[]");
+    const updatedSets = sets.map((s: FlashcardSet) =>
+      s.id === setData!.id ? setData : s
+    );
+
+    localStorage.setItem("flashcardSets", JSON.stringify(updatedSets));
+
+    setTimeout(() => {
+      router.push("/");
+    }, 2000);
+  };
+
+  if (!setData) return <p className="p-6">Loading set for editing...</p>;
+
   return (
     <div className="max-w-2xl mx-auto p-6 text-gray-800">
       <h1 className="text-3xl font-bold mb-6 text-blue-700">✏️ Edit Flashcard Set</h1>
@@ -105,7 +133,8 @@ export default function EditFlashcardSetPage() {
           onDelete={() => handleDeleteCard(index)}
         />
       ))}
-      <CardFormActions onAddCard={ } onSaveSet={ } />
+
+      <CardFormActions onAddCard={handleAddCard} onSaveSet={handleSubmit} />
     </div>
   );
 }

--- a/src/app/flashcards/edit/[setId]/page.tsx
+++ b/src/app/flashcards/edit/[setId]/page.tsx
@@ -1,39 +1,59 @@
 "use client";
+import { useParams, useRouter } from "next/navigation";
+import { useEffect, useState } from "react";
+import { FlashcardSet } from "@/lib/types";
+
 import FlashcardInput from "@/components/InputsFlashcard/FlashcardInput";
 import CardFormActions from "@/components/InputsFlashcard/CardFormActions";
 import SetDescriptionInput from "@/components/InputsFlashcard/SetDescriptionInput";
 import SetNameInput from "@/components/InputsFlashcard/SetNameInput";
 
 export default function EditFlashcardSetPage() {
+  const [notFound, setNotFound] = useState(false);
+  const { setId } = useParams();
+  const router = useRouter();
+  const [setData, setSetData] = useState<FlashcardSet | null>(null);
+
+  useEffect(() => {
+    const sets = JSON.parse(localStorage.getItem("flashcardSets") || "[]");
+    const found = sets.find((s: FlashcardSet) => s.id === setId);
+
+    if (!found && !notFound) {
+      setNotFound(true);
+      router.push("/");
+    } else {
+      setSetData(found);
+    }
+  }, [setId, notFound]);
 
   return (
     <div className="max-w-2xl mx-auto p-6 text-gray-800">
       <h1 className="text-3xl font-bold mb-6 text-blue-700">✏️ Edit Flashcard Set</h1>
 
       <SetNameInput
-        value={}
-        onChange={() =>()}
-        error={}
+        value={ }
+        onChange={() => ()}
+        error={ }
       />
 
       <SetDescriptionInput
-        value={}
+        value={ }
         onChange={() => ()}
       />
 
       <h2 className="text-xl font-semibold mb-4 text-blue-600">🧠 Cards</h2>
 
-      
-        <FlashcardInput
-          key={}
-          index={}
-          card={}
-          error={}
-          onChange={() => ()}
-          onDelete={() => ()}
-        />
 
-      <CardFormActions onAddCard={} onSaveSet={} />
+      <FlashcardInput
+        key={ }
+        index={ }
+        card={ }
+        error={ }
+        onChange={() => ()}
+        onDelete={() => ()}
+      />
+
+      <CardFormActions onAddCard={ } onSaveSet={ } />
     </div>
   );
 }

--- a/src/app/flashcards/edit/[setId]/page.tsx
+++ b/src/app/flashcards/edit/[setId]/page.tsx
@@ -13,6 +13,9 @@ export default function EditFlashcardSetPage() {
   const { setId } = useParams();
   const router = useRouter();
   const [setData, setSetData] = useState<FlashcardSet | null>(null);
+  const [errors, setErrors] = useState<{ name?: string; cards: string[] }>({
+    cards: [],
+  });
 
   useEffect(() => {
     const sets = JSON.parse(localStorage.getItem("flashcardSets") || "[]");
@@ -49,6 +52,32 @@ export default function EditFlashcardSetPage() {
     setSetData({ ...setData, cards: newCards });
   };
 
+  const validate = () => {
+    if (!setData) return false;
+
+    const newErrors = { name: "", cards: [] as string[] };
+
+    if (setData.name.trim() === "") {
+      newErrors.name = "The set name is required.";
+    }
+
+    if (setData.cards.length === 0) {
+      return false;
+    }
+
+    setData.cards.forEach((card, i) => {
+      if (card.front.trim() === "" || card.back.trim() === "") {
+        newErrors.cards[i] = `Complete card #${i + 1}`;
+      } else {
+        newErrors.cards[i] = "";
+      }
+    });
+
+    setErrors(newErrors);
+    const hasErrors = newErrors.name || newErrors.cards.some(Boolean);
+    return !hasErrors;
+  };
+
   return (
     <div className="max-w-2xl mx-auto p-6 text-gray-800">
       <h1 className="text-3xl font-bold mb-6 text-blue-700">✏️ Edit Flashcard Set</h1>
@@ -56,7 +85,7 @@ export default function EditFlashcardSetPage() {
       <SetNameInput
         value={setData.name}
         onChange={(value: string) => handleChange("name", value)}
-        error={}
+        error={errors.name}
       />
 
       <SetDescriptionInput
@@ -71,7 +100,7 @@ export default function EditFlashcardSetPage() {
           key={card.id}
           index={index}
           card={card}
-          error={ }
+          error={errors.cards[index]}
           onChange={(field, value) => handleCardChange(index, field, value)}
           onDelete={() => handleDeleteCard(index)}
         />

--- a/src/app/flashcards/edit/[setId]/page.tsx
+++ b/src/app/flashcards/edit/[setId]/page.tsx
@@ -1,0 +1,39 @@
+"use client";
+import FlashcardInput from "@/components/InputsFlashcard/FlashcardInput";
+import CardFormActions from "@/components/InputsFlashcard/CardFormActions";
+import SetDescriptionInput from "@/components/InputsFlashcard/SetDescriptionInput";
+import SetNameInput from "@/components/InputsFlashcard/SetNameInput";
+
+export default function EditFlashcardSetPage() {
+
+  return (
+    <div className="max-w-2xl mx-auto p-6 text-gray-800">
+      <h1 className="text-3xl font-bold mb-6 text-blue-700">✏️ Edit Flashcard Set</h1>
+
+      <SetNameInput
+        value={}
+        onChange={() =>()}
+        error={}
+      />
+
+      <SetDescriptionInput
+        value={}
+        onChange={() => ()}
+      />
+
+      <h2 className="text-xl font-semibold mb-4 text-blue-600">🧠 Cards</h2>
+
+      
+        <FlashcardInput
+          key={}
+          index={}
+          card={}
+          error={}
+          onChange={() => ()}
+          onDelete={() => ()}
+        />
+
+      <CardFormActions onAddCard={} onSaveSet={} />
+    </div>
+  );
+}

--- a/src/app/flashcards/edit/[setId]/page.tsx
+++ b/src/app/flashcards/edit/[setId]/page.tsx
@@ -42,6 +42,13 @@ export default function EditFlashcardSetPage() {
     setSetData({ ...setData, cards: newCards });
   };
 
+  const handleDeleteCard = (index: number) => {
+    if (!setData) return;
+    const newCards = [...setData.cards];
+    newCards.splice(index, 1);
+    setSetData({ ...setData, cards: newCards });
+  };
+
   return (
     <div className="max-w-2xl mx-auto p-6 text-gray-800">
       <h1 className="text-3xl font-bold mb-6 text-blue-700">✏️ Edit Flashcard Set</h1>
@@ -66,7 +73,7 @@ export default function EditFlashcardSetPage() {
           card={card}
           error={ }
           onChange={(field, value) => handleCardChange(index, field, value)}
-          onDelete={() => ()}
+          onDelete={() => handleDeleteCard(index)}
         />
       ))}
       <CardFormActions onAddCard={ } onSaveSet={ } />

--- a/src/app/flashcards/edit/[setId]/page.tsx
+++ b/src/app/flashcards/edit/[setId]/page.tsx
@@ -35,6 +35,13 @@ export default function EditFlashcardSetPage() {
     setSetData({ ...setData, [field]: value });
   };
 
+  const handleCardChange = (index: number, field: "front" | "back", value: string) => {
+    if (!setData) return;
+    const newCards = [...setData.cards];
+    newCards[index][field] = value;
+    setSetData({ ...setData, cards: newCards });
+  };
+
   return (
     <div className="max-w-2xl mx-auto p-6 text-gray-800">
       <h1 className="text-3xl font-bold mb-6 text-blue-700">✏️ Edit Flashcard Set</h1>
@@ -52,16 +59,16 @@ export default function EditFlashcardSetPage() {
 
       <h2 className="text-xl font-semibold mb-4 text-blue-600">🧠 Cards</h2>
 
-
-      <FlashcardInput
-        key={ }
-        index={ }
-        card={ }
-        error={ }
-        onChange={() => ()}
-        onDelete={() => ()}
-      />
-
+      {setData.cards.map((card, index) => (
+        <FlashcardInput
+          key={card.id}
+          index={index}
+          card={card}
+          error={ }
+          onChange={(field, value) => handleCardChange(index, field, value)}
+          onDelete={() => ()}
+        />
+      ))}
       <CardFormActions onAddCard={ } onSaveSet={ } />
     </div>
   );


### PR DESCRIPTION
This pull request introduces a major feature to the flashcards app: users can now edit existing flashcard sets. It adds a new page for editing, with full support for updating set details and individual cards, validation, and local storage integration. The README has also been rewritten to better document the app, its features, tech stack, and development workflow.

**Feature Addition: Edit Flashcard Sets**
* Added a new client-side page component `src/app/flashcards/edit/[setId]/page.tsx` that allows users to edit flashcard sets, including set name, description, and individual cards. It supports adding, deleting, and updating cards, with validation and local storage persistence. ([src/app/flashcards/edit/[setId]/page.tsxR1-R140](diffhunk://#diff-ccebe8920cdb1752212624a4e1ab20ffa7eb3af74a42f266a511a3e8e1cb45e2R1-R140))

**Documentation Improvements**
* Completely rewrote the `README.md` to describe the app, its features, folder structure, tech stack, setup instructions, testing, production build, notes about local storage, future improvements, and author information.