### PR TITLE
Notification implementation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "next": "15.4.5",
         "react": "19.1.0",
         "react-dom": "19.1.0",
+        "react-toastify": "^11.0.5",
         "uuid": "^11.1.0"
       },
       "devDependencies": {
@@ -4491,6 +4492,15 @@
       },
       "funding": {
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/co": {
@@ -9007,6 +9017,19 @@
         "@types/react": {
           "optional": true
         }
+      }
+    },
+    "node_modules/react-toastify": {
+      "version": "11.0.5",
+      "resolved": "https://registry.npmjs.org/react-toastify/-/react-toastify-11.0.5.tgz",
+      "integrity": "sha512-EpqHBGvnSTtHYhCPLxML05NLY2ZX0JURbAdNYa6BUkk+amz4wbKBQvoKQAB0ardvSarUBuY4Q4s1sluAzZwkmA==",
+      "license": "MIT",
+      "dependencies": {
+        "clsx": "^2.1.1"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19",
+        "react-dom": "^18 || ^19"
       }
     },
     "node_modules/redent": {

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "next": "15.4.5",
     "react": "19.1.0",
     "react-dom": "19.1.0",
+    "react-toastify": "^11.0.5",
     "uuid": "^11.1.0"
   },
   "devDependencies": {

--- a/src/app/ClientProviders.tsx
+++ b/src/app/ClientProviders.tsx
@@ -1,0 +1,9 @@
+// src/app/ClientProviders.tsx
+"use client";
+
+import { ToastContainer } from "react-toastify";
+import "react-toastify/dist/ReactToastify.css";
+
+export default function ClientProviders() {
+  return <ToastContainer position="top-center" autoClose={2500} />;
+}

--- a/src/app/flashcards/edit/[setId]/page.tsx
+++ b/src/app/flashcards/edit/[setId]/page.tsx
@@ -9,6 +9,7 @@ import FlashcardInput from "@/components/InputsFlashcard/FlashcardInput";
 import CardFormActions from "@/components/InputsFlashcard/CardFormActions";
 import SetDescriptionInput from "@/components/InputsFlashcard/SetDescriptionInput";
 import SetNameInput from "@/components/InputsFlashcard/SetNameInput";
+import { toast } from "react-toastify";
 
 export default function EditFlashcardSetPage() {
   const [notFound, setNotFound] = useState(false);
@@ -71,6 +72,7 @@ export default function EditFlashcardSetPage() {
     }
 
     if (setData.cards.length === 0) {
+      toast.error("There must be at least one flashcard.");
       return false;
     }
 
@@ -96,6 +98,8 @@ export default function EditFlashcardSetPage() {
     );
 
     localStorage.setItem("flashcardSets", JSON.stringify(updatedSets));
+
+    toast.success("Flashcard set updated successfully! ✅");
 
     setTimeout(() => {
       router.push("/");

--- a/src/app/flashcards/new/page.tsx
+++ b/src/app/flashcards/new/page.tsx
@@ -7,6 +7,7 @@ import FlashcardInput from "@/components/InputsFlashcard/FlashcardInput";
 import SetNameInput from "@/components/InputsFlashcard/SetNameInput";
 import SetDescriptionInput from "@/components/InputsFlashcard/SetDescriptionInput";
 import CardFormActions from "@/components/InputsFlashcard/CardFormActions";
+import { toast } from "react-toastify";
 
 export default function CreateFlashcardSetPage() {
   const [name, setName] = useState("");
@@ -70,6 +71,8 @@ export default function CreateFlashcardSetPage() {
 
     const existing = JSON.parse(localStorage.getItem("flashcardSets") || "[]");
     localStorage.setItem("flashcardSets", JSON.stringify([...existing, newSet]));
+
+    toast.success("Set saved successfully! 🎉");
 
     router.push("/");
   };

--- a/src/app/flashcards/new/page.tsx
+++ b/src/app/flashcards/new/page.tsx
@@ -42,6 +42,7 @@ export default function CreateFlashcardSetPage() {
     }
 
     if (cards.length === 0) {
+      toast.error("At least one card is required.");
       return false;
     }
 

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -4,6 +4,7 @@ import "@/styles/globals.css";
 
 import Header from "@/components/UI/Header";
 import Footer from "@/components/UI/Footer";
+import ClientProviders from "@/app/ClientProviders";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -33,6 +34,7 @@ export default function RootLayout({
       <body className="min-h-screen flex flex-col bg-[#f6f7fb] text-gray-800">
         <Header />
         <main className="flex-1">
+          <ClientProviders />
           {children}
         </main>
         <Footer />

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -24,7 +24,7 @@ export default function HomePage() {
     const updated = sets.filter((s) => s.id !== deleteId);
     setSets(updated);
     localStorage.setItem("flashcardSets", JSON.stringify(updated));
-    toast.success("Flashcard set deleted successfully!");
+    toast.success("Flashcard set deleted successfully! 🗑️");
     setDeleteId(null);
   };
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -6,6 +6,7 @@ import { FlashcardSet } from "@/lib/types";
 import DeleteModal from "@/components/DeleteModal";
 import HeaderSection from "@/components/Layout/HeaderSection";
 import FlashcardSetList from "@/components/Layout/FlashcardSetList";
+import { toast } from "react-toastify";
 
 export default function HomePage() {
   const [sets, setSets] = useState<FlashcardSet[]>([]);
@@ -23,6 +24,7 @@ export default function HomePage() {
     const updated = sets.filter((s) => s.id !== deleteId);
     setSets(updated);
     localStorage.setItem("flashcardSets", JSON.stringify(updated));
+    toast.success("Flashcard set deleted successfully!");
     setDeleteId(null);
   };
 


### PR DESCRIPTION
This pull request introduces toast notifications throughout the flashcard app to provide users with immediate feedback on key actions such as creating, editing, or deleting flashcard sets. The integration is achieved using the `react-toastify` library and a new `ClientProviders` component that enables toast rendering across the app.

**User feedback improvements:**

* Added toast notifications for successful creation, editing, and deletion of flashcard sets, as well as for validation errors (e.g., missing cards) in both the flashcard creation and editing pages (`src/app/flashcards/new/page.tsx`, `src/app/flashcards/edit/[setId]/page.tsx`, `src/app/page.tsx`). [[1]](diffhunk://#diff-e532ad97e2cf8dcb23696c71a690606f26483ff084e799765933a6f673a7b7f8R45) [[2]](diffhunk://#diff-e532ad97e2cf8dcb23696c71a690606f26483ff084e799765933a6f673a7b7f8R76-R77) [src/app/flashcards/edit/[setId]/page.tsxR75](diffhunk://#diff-ccebe8920cdb1752212624a4e1ab20ffa7eb3af74a42f266a511a3e8e1cb45e2R75), [src/app/flashcards/edit/[setId]/page.tsxR102-R103](diffhunk://#diff-ccebe8920cdb1752212624a4e1ab20ffa7eb3af74a42f266a511a3e8e1cb45e2R102-R103), [[3]](diffhunk://#diff-73d7a23e5015801b9bcc9db601d6ec9594d3eb34e5bb23154e0ae4b0c30f1a3bR27)

**Library and infrastructure changes:**

* Added the `react-toastify` dependency to `package.json` and imported it where needed. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R20) [src/app/flashcards/edit/[setId]/page.tsxR12](diffhunk://#diff-ccebe8920cdb1752212624a4e1ab20ffa7eb3af74a42f266a511a3e8e1cb45e2R12), [[2]](diffhunk://#diff-e532ad97e2cf8dcb23696c71a690606f26483ff084e799765933a6f673a7b7f8R10) [[3]](diffhunk://#diff-73d7a23e5015801b9bcc9db601d6ec9594d3eb34e5bb23154e0ae4b0c30f1a3bR9)
* Created a new `ClientProviders` component that renders the toast container and included it in the main layout to enable toast notifications throughout the app (`src/app/ClientProviders.tsx`, `src/app/layout.tsx`). [[1]](diffhunk://#diff-d425ce54157f012183dee850bdf8690eda1872df90c2a534fbae36a213388e5aR1-R9) [[2]](diffhunk://#diff-29d0a55f5ca1a9951042587f8b891bb4cd8b204f5bc855dc2468ed44cde2f5b3R7) [[3]](diffhunk://#diff-29d0a55f5ca1a9951042587f8b891bb4cd8b204f5bc855dc2468ed44cde2f5b3R37)