### PR TITLE
Creating unit tests using JEST

### DIFF
--- a/__test__/app/HomePage.test.tsx
+++ b/__test__/app/HomePage.test.tsx
@@ -1,0 +1,53 @@
+// __tests__/HomePage.test.tsx
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import HomePage from "@/app/page";
+import "@testing-library/jest-dom";
+import { useRouter } from "next/navigation";
+
+jest.mock("next/navigation", () => ({
+  useRouter: jest.fn(),
+}));
+
+jest.mock("react-toastify", () => {
+  const actual = jest.requireActual("react-toastify");
+  return {
+    ...actual,
+    toast: {
+      success: jest.fn(),
+    },
+    ToastContainer: () => <div />,
+  };
+});
+
+const mockSets = [
+  { id: "1", name: "Set 1", description: "Desc", cards: [] },
+  { id: "2", name: "Set 2", description: "Desc", cards: [] },
+];
+
+beforeEach(() => {
+  localStorage.setItem("flashcardSets", JSON.stringify(mockSets));
+  (useRouter as jest.Mock).mockReturnValue({ push: jest.fn() });
+});
+
+afterEach(() => {
+  localStorage.clear();
+  jest.clearAllMocks();
+});
+
+describe("HomePage", () => {
+  test("shows the localStorage sets", () => {
+    render(<HomePage />);
+    expect(screen.getByText("Set 1")).toBeInTheDocument();
+    expect(screen.getByText("Set 2")).toBeInTheDocument();
+  });
+  test("when clicking delete shows the modal", async () => {
+    render(<HomePage />);
+    const deleteButtons = screen.getAllByRole("button", {
+      name: /delete/i,
+    });
+    fireEvent.click(deleteButtons[0]);
+    await waitFor(() => {
+      expect(screen.getByText(/cancel/i)).toBeInTheDocument();
+    });
+  });
+});

--- a/__test__/app/flashcards/CreateFlashcardSetPage.test.tsx
+++ b/__test__/app/flashcards/CreateFlashcardSetPage.test.tsx
@@ -61,11 +61,11 @@ describe("CreateFlashcardSetPage validation tests", () => {
       target: { value: "My Set" },
     });
 
-    fireEvent.change(screen.getByPlaceholderText(/Frente #1/i), {
+    fireEvent.change(screen.getByPlaceholderText(/Front #/i), {
       target: { value: "Front content" },
     });
 
-    fireEvent.change(screen.getByPlaceholderText(/Back #1/i), {
+    fireEvent.change(screen.getByPlaceholderText(/Back #/i), {
       target: { value: "Back content" },
     });
     fireEvent.click(screen.getByText(/Save Set/i));

--- a/__test__/app/flashcards/CreateFlashcardSetPage.test.tsx
+++ b/__test__/app/flashcards/CreateFlashcardSetPage.test.tsx
@@ -1,0 +1,78 @@
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import CreateFlashcardSetPage from "@/app/flashcards/new/page";
+import { toast } from "react-toastify";
+
+jest.mock("react-toastify", () => ({
+  toast: {
+    error: jest.fn(),
+    success: jest.fn(),
+  },
+}));
+
+const pushMock = jest.fn();
+
+jest.mock("next/navigation", () => ({
+  useRouter: () => ({
+    push: pushMock,
+  }),
+}));
+
+describe("CreateFlashcardSetPage validation tests", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test("shows error if name is empty", () => {
+    render(<CreateFlashcardSetPage />);
+    fireEvent.click(screen.getByText(/Save Set/i));
+    expect(screen.getByText(/The set name is required./i)).toBeInTheDocument();
+  });
+
+  test("shows toast error if no cards exist", () => {
+    render(<CreateFlashcardSetPage />);
+
+    const deleteButtons = screen.getAllByText(/Delete Card/i);
+    deleteButtons.forEach((btn) => fireEvent.click(btn));
+
+    fireEvent.click(screen.getByText(/Save Set/i));
+
+    expect(toast.error).toHaveBeenCalledWith("At least one card is required.");
+  });
+
+  test("shows card error if any card front or back is empty", () => {
+    render(<CreateFlashcardSetPage />);
+
+    const nameInput = screen.getByPlaceholderText(/Name of the Set \*/i);
+    fireEvent.change(nameInput, { target: { value: "My Set" } });
+
+    fireEvent.click(screen.getByText(/Save Set/i));
+
+    expect(screen.getByText(/Complete card #1/i)).toBeInTheDocument();
+  });
+
+
+
+  test("saves successfully when all fields are valid", async () => {
+    jest.useFakeTimers();
+
+    render(<CreateFlashcardSetPage />);
+
+    fireEvent.change(screen.getByPlaceholderText(/Name of the Set \*/i), {
+      target: { value: "My Set" },
+    });
+
+    fireEvent.change(screen.getByPlaceholderText(/Frente #1/i), {
+      target: { value: "Front content" },
+    });
+
+    fireEvent.change(screen.getByPlaceholderText(/Back #1/i), {
+      target: { value: "Back content" },
+    });
+    fireEvent.click(screen.getByText(/Save Set/i));
+    expect(toast.success).toHaveBeenCalledWith("Set saved successfully! 🎉");
+    jest.advanceTimersByTime(2200);
+    expect(pushMock).toHaveBeenCalledWith("/");
+    jest.useRealTimers();
+  });
+
+});

--- a/__test__/app/flashcards/EditFlashcard.test.tsx
+++ b/__test__/app/flashcards/EditFlashcard.test.tsx
@@ -1,0 +1,58 @@
+// tests/EditFlashcardSetPage.test.tsx
+import "@testing-library/jest-dom";
+import { render, screen, waitFor } from "@testing-library/react";
+import EditFlashcardSetPage from "@/app/flashcards/edit/[setId]/page"; // ajusta esta ruta si es diferente
+import React from "react";
+
+jest.mock("next/navigation", () => ({
+  useRouter: () => ({
+    push: jest.fn(),
+  }),
+  useParams: () => ({
+    setId: "abc123",
+  }),
+}));
+
+const mockSet = {
+  id: "abc123",
+  name: "Test Set",
+  description: "Descripción del set",
+  cards: [
+    { id: "card1", front: "Front 1", back: "Back 1" },
+    { id: "card2", front: "Front 2", back: "Back 2" },
+  ],
+};
+
+beforeEach(() => {
+  localStorage.setItem("flashcardSets", JSON.stringify([mockSet]));
+});
+
+afterEach(() => {
+  localStorage.clear();
+});
+
+describe("EditFlashcardSetPage", () => {
+  it("renderiza el formulario de edición si el set existe", async () => {
+    render(<EditFlashcardSetPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText("✏️ Edit Flashcard Set")).toBeInTheDocument();
+      expect(screen.getByDisplayValue("Test Set")).toBeInTheDocument();
+      expect(screen.getByDisplayValue("Descripción del set")).toBeInTheDocument();
+      expect(screen.getByDisplayValue("Front 1")).toBeInTheDocument();
+      expect(screen.getByDisplayValue("Back 1")).toBeInTheDocument();
+    });
+  });
+
+  it("redirige si el set no existe", async () => {
+    localStorage.setItem("flashcardSets", JSON.stringify([])); // vacía
+
+    const mockPush = jest.fn();
+    jest.mocked(require("next/navigation")).useRouter = () => ({ push: mockPush });
+    render(<EditFlashcardSetPage />);
+
+    await waitFor(() => {
+      expect(mockPush).toHaveBeenCalledWith("/");
+    });
+  });
+});

--- a/__test__/app/flashcards/FlashcardSetPage.test.tsx
+++ b/__test__/app/flashcards/FlashcardSetPage.test.tsx
@@ -1,0 +1,92 @@
+import React from "react";
+import { render, screen, waitFor, fireEvent } from "@testing-library/react";
+import FlashcardSetPage from "@/app/flashcards/[setId]/page";
+import * as nextRouter from "next/navigation";
+
+const mockPush = jest.fn();
+
+jest.mock("next/navigation", () => ({
+    ...jest.requireActual("next/navigation"),
+    useRouter: jest.fn(),
+    useParams: jest.fn(),
+}));
+
+beforeEach(() => {
+    jest.clearAllMocks();
+    localStorage.clear();
+
+    (nextRouter.useRouter as jest.Mock).mockReturnValue({ push: mockPush });
+});
+
+describe("FlashcardSetPage", () => {
+    it("redirects if setId is missing", () => {
+        (nextRouter.useParams as jest.Mock).mockReturnValue({});
+
+        render(<FlashcardSetPage />);
+        expect(mockPush).toHaveBeenCalledWith("/");
+    });
+
+    it("redirects if no matching set found", () => {
+        (nextRouter.useParams as jest.Mock).mockReturnValue({ setId: "abc123" });
+
+        localStorage.setItem("flashcardSets", JSON.stringify([]));
+
+        render(<FlashcardSetPage />);
+        expect(mockPush).toHaveBeenCalledWith("/");
+    });
+
+    it("shows loading initially", () => {
+        (nextRouter.useParams as jest.Mock).mockReturnValue({ setId: "abc123" });
+        localStorage.setItem("flashcardSets", JSON.stringify([]));
+
+        render(<FlashcardSetPage />);
+        expect(screen.getByText(/Loading set/i)).toBeInTheDocument();
+    });
+
+    it("renders set correctly", async () => {
+        const testSet = {
+            id: "abc123",
+            name: "Test Set",
+            description: "Set Description",
+            cards: [
+                { front: "Front 1", back: "Back 1" },
+                { front: "Front 2", back: "Back 2" },
+            ],
+        };
+
+        (nextRouter.useParams as jest.Mock).mockReturnValue({ setId: "abc123" });
+        localStorage.setItem("flashcardSets", JSON.stringify([testSet]));
+
+        render(<FlashcardSetPage />);
+
+        await waitFor(() =>
+            expect(screen.getByText("Test Set")).toBeInTheDocument()
+        );
+
+        expect(screen.getByText("Set Description")).toBeInTheDocument();
+        expect(screen.getByText("Front 1")).toBeInTheDocument();
+
+        // Flip card
+        fireEvent.click(screen.getByText("(Click to flip)"));
+        expect(screen.getByText("Back 1")).toBeInTheDocument();
+
+    });
+
+    it("renders fallback if no cards exist", async () => {
+        const emptySet = {
+            id: "empty123",
+            name: "Empty Set",
+            description: "",
+            cards: [],
+        };
+
+        (nextRouter.useParams as jest.Mock).mockReturnValue({ setId: "empty123" });
+        localStorage.setItem("flashcardSets", JSON.stringify([emptySet]));
+
+        render(<FlashcardSetPage />);
+
+        await waitFor(() =>
+            expect(screen.getByText(/This set has no cards yet/i)).toBeInTheDocument()
+        );
+    });
+});

--- a/__test__/components/DeleteModal.test.tsx
+++ b/__test__/components/DeleteModal.test.tsx
@@ -1,0 +1,65 @@
+// __tests__/DeleteModal.test.tsx
+import React from "react";
+import { render, screen, fireEvent } from "@testing-library/react";
+import DeleteModal from "@/components/DeleteModal";
+
+describe("DeleteModal", () => {
+  const onClose = jest.fn();
+  const onConfirm = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test("renders modal with default texts when open", () => {
+    render(
+      <DeleteModal open={true} onClose={onClose} onConfirm={onConfirm} />
+    );
+
+    expect(screen.getByText("Delete this set?")).toBeInTheDocument();
+    expect(screen.getByText("This action cannot be undone.")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /cancel/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /delete/i })).toBeInTheDocument();
+  });
+
+  test("calls onClose when clicking Cancel button", () => {
+    render(
+      <DeleteModal open={true} onClose={onClose} onConfirm={onConfirm} />
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /cancel/i }));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  test("calls onConfirm and onClose when clicking Delete button", () => {
+    render(
+      <DeleteModal open={true} onClose={onClose} onConfirm={onConfirm} />
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /delete/i }));
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  test("does not render content when open is false", () => {
+    render(
+      <DeleteModal open={false} onClose={onClose} onConfirm={onConfirm} />
+    );
+    
+    expect(screen.queryByText("Delete this set?")).not.toBeInTheDocument();
+  });
+
+  test("renders custom title and description if provided", () => {
+    render(
+      <DeleteModal
+        open={true}
+        onClose={onClose}
+        onConfirm={onConfirm}
+        title="Custom Title"
+        description="Custom description text."
+      />
+    );
+    expect(screen.getByText("Custom Title")).toBeInTheDocument();
+    expect(screen.getByText("Custom description text.")).toBeInTheDocument();
+  });
+});

--- a/__test__/components/Flashcard/Flashcard.test.tsx
+++ b/__test__/components/Flashcard/Flashcard.test.tsx
@@ -1,0 +1,43 @@
+// __tests__/Flashcard.test.tsx
+import React from "react";
+import { render, screen, fireEvent } from "@testing-library/react";
+import Flashcard from "@/components/Flashcard/Flashcard";
+
+describe("Flashcard component", () => {
+  it("renders front text initially and calls onFlip on click", () => {
+    const frontText = "Front side";
+    const backText = "Back side";
+    const onFlip = jest.fn();
+
+    render(<Flashcard front={frontText} back={backText} showBack={false} onFlip={onFlip} />);
+
+    // Should show front text
+    expect(screen.getByText(frontText)).toBeInTheDocument();
+
+    // The back text should be present but not visible (due to CSS backfaceVisibility)
+    expect(screen.getByText(backText)).toBeInTheDocument();
+
+    // Click the card
+    fireEvent.click(screen.getByText(frontText).parentElement!.parentElement!);
+
+    // onFlip should have been called once
+    expect(onFlip).toHaveBeenCalledTimes(1);
+  });
+
+  it("shows back text when showBack is true", () => {
+    const frontText = "Front side";
+    const backText = "Back side";
+    const onFlip = jest.fn();
+
+    render(<Flashcard front={frontText} back={backText} showBack={true} onFlip={onFlip} />);
+
+    // The front text should be present
+    expect(screen.getByText(frontText)).toBeInTheDocument();
+
+    // The back text should be present
+    expect(screen.getByText(backText)).toBeInTheDocument();
+
+    // Since CSS handles visibility via backfaceVisibility and rotateY, 
+    // we rely on the props and presence of text only in this test.
+  });
+});

--- a/__test__/components/Flashcard/FlashcardNavigation.test.tsx
+++ b/__test__/components/Flashcard/FlashcardNavigation.test.tsx
@@ -1,0 +1,45 @@
+// __tests__/FlashcardNavigation.test.tsx
+import React from "react";
+import { render, screen, fireEvent } from "@testing-library/react";
+import FlashcardNavigation from "@/components/Flashcard/FlashcardNavigation";
+
+describe("FlashcardNavigation", () => {
+  const onPrev = jest.fn();
+  const onNext = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("renders buttons with correct disabled states", () => {
+    // Current = 0 (first card), Prev disabled, Next enabled
+    render(<FlashcardNavigation current={0} total={3} onPrev={onPrev} onNext={onNext} />);
+    expect(screen.getByText(/Previous/i)).toBeDisabled();
+    expect(screen.getByText(/Next/i)).toBeEnabled();
+  });
+
+  it("disables Next button on last card", () => {
+    // Current = total - 1, Next disabled, Prev enabled
+    render(<FlashcardNavigation current={2} total={3} onPrev={onPrev} onNext={onNext} />);
+    expect(screen.getByText(/Previous/i)).toBeEnabled();
+    expect(screen.getByText(/Next/i)).toBeDisabled();
+  });
+
+  it("disables both buttons when total is 0", () => {
+    render(<FlashcardNavigation current={0} total={0} onPrev={onPrev} onNext={onNext} />);
+    expect(screen.getByText(/Previous/i)).toBeDisabled();
+    expect(screen.getByText(/Next/i)).toBeDisabled();
+  });
+
+  it("calls onPrev when Previous button is clicked", () => {
+    render(<FlashcardNavigation current={1} total={3} onPrev={onPrev} onNext={onNext} />);
+    fireEvent.click(screen.getByText(/Previous/i));
+    expect(onPrev).toHaveBeenCalledTimes(1);
+  });
+
+  it("calls onNext when Next button is clicked", () => {
+    render(<FlashcardNavigation current={1} total={3} onPrev={onPrev} onNext={onNext} />);
+    fireEvent.click(screen.getByText(/Next/i));
+    expect(onNext).toHaveBeenCalledTimes(1);
+  });
+});

--- a/__test__/components/Flashcard/ProgressBar.test.tsx
+++ b/__test__/components/Flashcard/ProgressBar.test.tsx
@@ -1,0 +1,25 @@
+// __tests__/ProgressBar.test.tsx
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import ProgressBar from "@/components/Flashcard/ProgressBar";
+
+describe("ProgressBar", () => {
+  it("renders correct progress width and text", () => {
+    const current = 2;
+    const total = 5;
+    render(<ProgressBar current={current} total={total} />);
+
+    const progressDiv = screen.getByTestId("progress-bar");
+    expect(progressDiv).toHaveStyle(`width: 60%`);
+
+    expect(screen.getByText(/Card 3 of 5/i)).toBeInTheDocument();
+  });
+
+  it("shows 0% progress and 'Card 1 of 0' if total is 0", () => {
+    render(<ProgressBar current={0} total={0} />);
+    const progressDiv = screen.getByTestId("progress-bar");
+
+    expect(progressDiv).toHaveStyle(`width: 0%`);
+    expect(screen.getByText(/Card 1 of 0/i)).toBeInTheDocument();
+  });
+});

--- a/__test__/components/InputsFlashcard/CardFormActions.test.tsx
+++ b/__test__/components/InputsFlashcard/CardFormActions.test.tsx
@@ -1,0 +1,30 @@
+// __tests__/CardFormActions.test.tsx
+import React from "react";
+import { render, screen, fireEvent } from "@testing-library/react";
+import CardFormActions from "@/components/InputsFlashcard/CardFormActions";
+
+describe("CardFormActions", () => {
+  it("calls onAddCard when 'Add Card' button is clicked", () => {
+    const onAddCard = jest.fn();
+    const onSaveSet = jest.fn();
+
+    render(<CardFormActions onAddCard={onAddCard} onSaveSet={onSaveSet} />);
+
+    const addButton = screen.getByRole("button", { name: /add card/i });
+    fireEvent.click(addButton);
+
+    expect(onAddCard).toHaveBeenCalledTimes(1);
+  });
+
+  it("calls onSaveSet when 'Save Set' button is clicked", () => {
+    const onAddCard = jest.fn();
+    const onSaveSet = jest.fn();
+
+    render(<CardFormActions onAddCard={onAddCard} onSaveSet={onSaveSet} />);
+
+    const saveButton = screen.getByRole("button", { name: /save set/i });
+    fireEvent.click(saveButton);
+
+    expect(onSaveSet).toHaveBeenCalledTimes(1);
+  });
+});

--- a/__test__/components/InputsFlashcard/FlashcardInput.test.tsx
+++ b/__test__/components/InputsFlashcard/FlashcardInput.test.tsx
@@ -16,8 +16,8 @@ describe("FlashcardInput", () => {
       />
     );
 
-    expect(screen.getByPlaceholderText(/frente #1/i)).toHaveValue("front text");
-    expect(screen.getByPlaceholderText(/back #1/i)).toHaveValue("back text");
+    expect(screen.getByPlaceholderText(/front #/i)).toHaveValue("front text");
+    expect(screen.getByPlaceholderText(/back #/i)).toHaveValue("back text");
   });
 
   it("calls onChange with 'front' when front input changes", () => {
@@ -32,7 +32,7 @@ describe("FlashcardInput", () => {
       />
     );
 
-    fireEvent.change(screen.getByPlaceholderText(/frente #1/i), {
+    fireEvent.change(screen.getByPlaceholderText(/front #/i), {
       target: { value: "new front" },
     });
 
@@ -51,7 +51,7 @@ describe("FlashcardInput", () => {
       />
     );
 
-    fireEvent.change(screen.getByPlaceholderText(/back #1/i), {
+    fireEvent.change(screen.getByPlaceholderText(/back #/i), {
       target: { value: "new back" },
     });
 

--- a/__test__/components/InputsFlashcard/FlashcardInput.test.tsx
+++ b/__test__/components/InputsFlashcard/FlashcardInput.test.tsx
@@ -1,0 +1,91 @@
+// __tests__/FlashcardInput.test.tsx
+import React from "react";
+import { render, screen, fireEvent } from "@testing-library/react";
+import FlashcardInput from "@/components/InputsFlashcard/FlashcardInput";
+
+describe("FlashcardInput", () => {
+  const mockCard = { front: "front text", back: "back text", id: "1" };
+
+  it("renders inputs with correct initial values and placeholders", () => {
+    render(
+      <FlashcardInput
+        index={0}
+        card={mockCard}
+        onChange={jest.fn()}
+        onDelete={jest.fn()}
+      />
+    );
+
+    expect(screen.getByPlaceholderText(/frente #1/i)).toHaveValue("front text");
+    expect(screen.getByPlaceholderText(/back #1/i)).toHaveValue("back text");
+  });
+
+  it("calls onChange with 'front' when front input changes", () => {
+    const onChange = jest.fn();
+
+    render(
+      <FlashcardInput
+        index={0}
+        card={mockCard}
+        onChange={onChange}
+        onDelete={jest.fn()}
+      />
+    );
+
+    fireEvent.change(screen.getByPlaceholderText(/frente #1/i), {
+      target: { value: "new front" },
+    });
+
+    expect(onChange).toHaveBeenCalledWith("front", "new front");
+  });
+
+  it("calls onChange with 'back' when back input changes", () => {
+    const onChange = jest.fn();
+
+    render(
+      <FlashcardInput
+        index={0}
+        card={mockCard}
+        onChange={onChange}
+        onDelete={jest.fn()}
+      />
+    );
+
+    fireEvent.change(screen.getByPlaceholderText(/back #1/i), {
+      target: { value: "new back" },
+    });
+
+    expect(onChange).toHaveBeenCalledWith("back", "new back");
+  });
+
+  it("displays error message when error prop is passed", () => {
+    render(
+      <FlashcardInput
+        index={0}
+        card={mockCard}
+        error="This is an error"
+        onChange={jest.fn()}
+        onDelete={jest.fn()}
+      />
+    );
+
+    expect(screen.getByText(/this is an error/i)).toBeInTheDocument();
+  });
+
+  it("calls onDelete when Delete Card button is clicked", () => {
+    const onDelete = jest.fn();
+
+    render(
+      <FlashcardInput
+        index={0}
+        card={mockCard}
+        onChange={jest.fn()}
+        onDelete={onDelete}
+      />
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /delete card/i }));
+
+    expect(onDelete).toHaveBeenCalledTimes(1);
+  });
+});

--- a/__test__/components/InputsFlashcard/SetDescriptionInput.test.tsx
+++ b/__test__/components/InputsFlashcard/SetDescriptionInput.test.tsx
@@ -1,0 +1,23 @@
+// __tests__/SetDescriptionInput.test.tsx
+import React from "react";
+import { render, screen, fireEvent } from "@testing-library/react";
+import SetDescriptionInput from "@/components/InputsFlashcard/SetDescriptionInput";
+
+describe("SetDescriptionInput", () => {
+  it("renders the textarea with initial value", () => {
+    render(<SetDescriptionInput value="initial description" onChange={() => {}} />);
+    const textarea = screen.getByPlaceholderText(/description/i);
+    expect(textarea).toBeInTheDocument();
+    expect(textarea).toHaveValue("initial description");
+  });
+
+  it("calls onChange when typing in the textarea", () => {
+    const handleChange = jest.fn();
+    render(<SetDescriptionInput value="" onChange={handleChange} />);
+    const textarea = screen.getByPlaceholderText(/description/i);
+
+    fireEvent.change(textarea, { target: { value: "New description" } });
+
+    expect(handleChange).toHaveBeenCalledWith("New description");
+  });
+});

--- a/__test__/components/InputsFlashcard/SetNameInput.test.tsx
+++ b/__test__/components/InputsFlashcard/SetNameInput.test.tsx
@@ -1,0 +1,29 @@
+// __tests__/SetNameInput.test.tsx
+import React from "react";
+import { render, screen, fireEvent } from "@testing-library/react";
+import SetNameInput from "@/components/InputsFlashcard/SetNameInput";
+
+describe("SetNameInput", () => {
+  it("renders input with initial value", () => {
+    render(<SetNameInput value="My Set" onChange={() => {}} />);
+    const input = screen.getByPlaceholderText(/name of the set \*/i);
+    expect(input).toBeInTheDocument();
+    expect(input).toHaveValue("My Set");
+  });
+
+  it("calls onChange when typing", () => {
+    const handleChange = jest.fn();
+    render(<SetNameInput value="" onChange={handleChange} />);
+    const input = screen.getByPlaceholderText(/name of the set \*/i);
+
+    fireEvent.change(input, { target: { value: "New Name" } });
+
+    expect(handleChange).toHaveBeenCalledWith("New Name");
+  });
+
+  it("shows error message when error prop is passed", () => {
+    render(<SetNameInput value="" onChange={() => {}} error="Required field" />);
+    const errorMsg = screen.getByText(/required field/i);
+    expect(errorMsg).toBeInTheDocument();
+  });
+});

--- a/__test__/components/Layout/FlashcardSetList.test.tsx
+++ b/__test__/components/Layout/FlashcardSetList.test.tsx
@@ -1,0 +1,74 @@
+// __tests__/FlashcardSetList.test.tsx
+import React from "react";
+import { render, screen, fireEvent } from "@testing-library/react";
+import FlashcardSetList from "@/components/Layout/FlashcardSetList";
+import { FlashcardSet } from "@/lib/types";
+
+jest.mock("next/navigation", () => ({
+  useRouter() {
+    return {
+      push: jest.fn(),
+    };
+  },
+}));
+
+const mockSets: FlashcardSet[] = [
+  {
+    id: "1",
+    name: "Set One",
+    description: "Description One",
+    cards: [
+      { id: "c1", front: "front1", back: "back1" },
+      { id: "c2", front: "front2", back: "back2" },
+    ],
+  },
+  {
+    id: "2",
+    name: "Set Two",
+    description: "Description Two",
+    cards: [{ id: "c3", front: "front3", back: "back3" }],
+  },
+];
+
+describe("FlashcardSetList", () => {
+  test("renders no sets message when list is empty", () => {
+    render(<FlashcardSetList sets={[]} onEdit={jest.fn()} onDelete={jest.fn()} />);
+    expect(screen.getByText(/no sets created yet/i)).toBeInTheDocument();
+  });
+
+  test("renders flashcard sets correctly", () => {
+    render(<FlashcardSetList sets={mockSets} onEdit={jest.fn()} onDelete={jest.fn()} />);
+
+    expect(screen.getByText("Set One")).toBeInTheDocument();
+    expect(screen.getByText("Description One")).toBeInTheDocument();
+    expect(screen.getByText("2 cards")).toBeInTheDocument();
+
+    expect(screen.getByText("Set Two")).toBeInTheDocument();
+    expect(screen.getByText("Description Two")).toBeInTheDocument();
+    expect(screen.getByText("1 card")).toBeInTheDocument();
+  });
+
+  test("calls onEdit with correct id when Edit button clicked", () => {
+    const onEdit = jest.fn();
+    render(<FlashcardSetList sets={mockSets} onEdit={onEdit} onDelete={jest.fn()} />);
+
+    const editButtons = screen.getAllByRole("button", { name: /edit/i });
+    fireEvent.click(editButtons[0]);
+    expect(onEdit).toHaveBeenCalledWith("1");
+
+    fireEvent.click(editButtons[1]);
+    expect(onEdit).toHaveBeenCalledWith("2");
+  });
+
+  test("calls onDelete with correct id when Delete button clicked", () => {
+    const onDelete = jest.fn();
+    render(<FlashcardSetList sets={mockSets} onEdit={jest.fn()} onDelete={onDelete} />);
+
+    const deleteButtons = screen.getAllByRole("button", { name: /delete/i });
+    fireEvent.click(deleteButtons[0]);
+    expect(onDelete).toHaveBeenCalledWith("1");
+
+    fireEvent.click(deleteButtons[1]);
+    expect(onDelete).toHaveBeenCalledWith("2");
+  });
+});

--- a/__test__/sum.test.ts
+++ b/__test__/sum.test.ts
@@ -1,9 +1,0 @@
-// __test__/sum.test.ts
-
-function sum(a: number, b: number) {
-  return a + b;
-}
-
-test('sum adds 1 + 2 to equal 3', () => {
-  expect(sum(1, 2)).toBe(3);
-});


### PR DESCRIPTION
This pull request adds comprehensive unit tests for key pages and components in the flashcard app, significantly improving test coverage and reliability. The new tests cover user interactions, validation logic, rendering, and edge cases for flashcard set management and individual flashcard components.

**Page-level tests:**

* Added tests for the `HomePage`, verifying rendering of flashcard sets from localStorage and the delete modal interaction. (__test__/app/HomePage.test.tsx)
* Added validation and success scenario tests for creating a flashcard set, including error handling for missing fields and cards. (__test__/app/flashcards/CreateFlashcardSetPage.test.tsx)
* Added tests for editing flashcard sets, covering both successful rendering and redirection when the set does not exist. (__test__/app/flashcards/EditFlashcard.test.tsx)
* Added tests for viewing a flashcard set, including redirection if the set is missing, loading state, card flipping, and empty set fallback. (__test__/app/flashcards/FlashcardSetPage.test.tsx)

**Component-level tests:**

* Added tests for the `DeleteModal` component, covering rendering, callbacks, and custom text support. (__test__/components/DeleteModal.test.tsx)
* Added tests for the `Flashcard` component, verifying front/back rendering and flip interaction. (__test__/components/Flashcard/Flashcard.test.tsx)
* Added tests for the `FlashcardNavigation` component, checking button states and navigation callbacks. (__test__/components/Flashcard/FlashcardNavigation.test.tsx)
* Added tests for the `ProgressBar` component, verifying progress calculation and display. (__test__/components/Flashcard/ProgressBar.test.tsx)
* Added tests for flashcard input components (`FlashcardInput`, `SetNameInput`, `SetDescriptionInput`, `CardFormActions`), covering input changes, error display, and button actions. (__test__/components/InputsFlashcard/FlashcardInput.test.tsx, __test__/components/InputsFlashcard/SetNameInput.test.tsx, __test__/components/InputsFlashcard/SetDescriptionInput.test.tsx, __test__/components/InputsFlashcard/CardFormActions.test.tsx) [[1]](diffhunk://#diff-0328542d8eb5c6ba111101259a262681f8b360ad628a30c26361a93190561369R1-R91) [[2]](diffhunk://#diff-e8eee585b0675b1602f0e2f4abb97a01ce02af5c5276a1779682a1e36799b33dR1-R29) [[3]](diffhunk://#diff-d894a9f073d702edbc309ca04417e8425c3c2eb4c41f4485625b96b3202f1303R1-R23) [[4]](diffhunk://#diff-b61d0c9f72a0b32f7df553d015b3b800e2e991c95ee811b559373031ce05566aR1-R30)